### PR TITLE
Revert "chore(gitignore): won't pop up in changelog"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ env/
 # IntelliJ
 .idea/
 *.iml
-
-something-that-should-never-be-there-anyway
-


### PR DESCRIPTION
This reverts commit 814190faa02f0f23ca6fba9a7a1b88e2ac961f55.

CHANGELOG remove change introduced by previous merge. P.S: This line is also in a merge-commit
